### PR TITLE
Implement maintainer inspection workflow

### DIFF
--- a/src/app/api/inspecao/context/route.ts
+++ b/src/app/api/inspecao/context/route.ts
@@ -60,24 +60,49 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "TEMPLATE_NOT_FOUND" }, { status: 404 });
     }
 
-    const templateData = templateSnap.data();
+    const templateData = templateSnap.data() ?? {};
+
+    const issuesSnap = await adminDb
+      .collection("issues")
+      .where("machineId", "==", machineDoc.id)
+      .where("status", "==", "aberta")
+      .get();
+
+    const openIssues = issuesSnap.docs.map(doc => {
+      const data = doc.data() ?? {};
+      return {
+        id: doc.id,
+        templateItemId: data.templateItemId ?? null,
+        descricao: data.descricao ?? null,
+        osNumero: data.osNumero ?? null,
+        createdAt: data.createdAt ?? null,
+      };
+    });
 
     return NextResponse.json({
+      maintainer: {
+        id: auth.store.id!,
+        nome: auth.store.nome ?? null,
+        matricula: auth.store.matricula ?? null,
+      },
       machine: {
-        machineId: machineDoc.id,
+        id: machineDoc.id,
         tag: machineData.tag ?? null,
         nome: machineData.nome ?? null,
         setor: machineData.setor ?? null,
         unidade: machineData.unidade ?? null,
         localUnidade: machineData.localUnidade ?? null,
+        lac: machineData.lac ?? null,
         fotoUrl: machineData.fotoUrl ?? null,
         templateId,
       },
       template: {
         id: templateSnap.id,
-        ...templateData,
+        nome: templateData.nome ?? null,
+        imagemUrl: templateData.imagemUrl ?? null,
+        itens: Array.isArray(templateData.itens) ? templateData.itens : [],
       },
-      issues: [],
+      openIssues,
     });
   } catch (error: unknown) {
     return NextResponse.json(

--- a/src/app/api/inspecoes/[id]/pdf/route.ts
+++ b/src/app/api/inspecoes/[id]/pdf/route.ts
@@ -1,0 +1,231 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jsPDF } from "jspdf";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireAdmin, requireMaint } from "@/lib/guards";
+
+type TemplateItemData = {
+  id?: string;
+  componente?: string;
+};
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+async function fetchImageData(url: string | null | undefined) {
+  if (!url) return null;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const mime = response.headers.get("content-type") || "image/jpeg";
+    let format: "PNG" | "JPEG" | "WEBP" = "JPEG";
+    if (mime.includes("png")) format = "PNG";
+    else if (mime.includes("webp")) format = "WEBP";
+    const base64 = buffer.toString("base64");
+    return { base64, format };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveSession() {
+  const admin = await requireAdmin();
+  if (admin.ok) {
+    return { role: "admin" as const };
+  }
+  const maint = await requireMaint();
+  if (maint.ok) {
+    return { role: "maint" as const, store: maint.store };
+  }
+  return null;
+}
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  const session = await resolveSession();
+  if (!session) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  try {
+    const inspectionDoc = await adminDb.collection("inspecoes").doc(params.id).get();
+    if (!inspectionDoc.exists) {
+      return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+    }
+
+    const inspectionData = inspectionDoc.data() ?? {};
+    const maintainer = inspectionData.maintainer ?? {};
+    const machine = inspectionData.machine ?? {};
+    const template = inspectionData.template ?? {};
+    const itens: Array<{ templateItemId: string; resultado: string; observacaoItem?: string | null }> = Array.isArray(
+      inspectionData.itens
+    )
+      ? inspectionData.itens
+      : [];
+
+    if (session.role === "maint") {
+      const ownInspection = maintainer?.maintId === session.store.id;
+      if (!ownInspection) {
+        const maintDoc = await adminDb.collection("mantenedores").doc(session.store.id!).get();
+        if (!maintDoc.exists) {
+          return NextResponse.json({ error: "FORBIDDEN" }, { status: 403 });
+        }
+        const machines = Array.isArray(maintDoc.data()?.machines) ? (maintDoc.data()?.machines as string[]) : [];
+        if (!machine?.machineId || !machines.includes(machine.machineId)) {
+          return NextResponse.json({ error: "FORBIDDEN" }, { status: 403 });
+        }
+      }
+    }
+
+    const templateId = template?.id ? String(template.id) : machine?.templateId ? String(machine.templateId) : null;
+    let templateItemsMap = new Map<string, TemplateItemData>();
+    if (templateId) {
+      const templateDoc = await adminDb.collection("templates").doc(templateId).get();
+      if (templateDoc.exists) {
+        const templateData = templateDoc.data() ?? {};
+        const itensArr = Array.isArray(templateData.itens)
+          ? (templateData.itens as TemplateItemData[])
+          : [];
+        templateItemsMap = new Map(
+          itensArr
+            .filter(item => item?.id)
+            .map(item => [String(item.id), item])
+        );
+      }
+    }
+
+    const doc = new jsPDF();
+    const margin = 14;
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    let cursorY = 20;
+
+    doc.setFontSize(18);
+    doc.text("Relatório de Inspeção", margin, cursorY);
+    cursorY += 10;
+
+    doc.setFontSize(12);
+    const finalizedAt = inspectionData.finalizadaEm ?? inspectionData.createdAt;
+    const headerLines = [
+      `Unidade: ${machine?.unidade ?? "-"}`,
+      `Local: ${machine?.localUnidade ?? "-"}`,
+      `Setor: ${machine?.setor ?? "-"}`,
+      `Máquina: ${machine?.nome ?? "-"}`,
+      `TAG: ${machine?.tag ?? "-"}`,
+      `LAC: ${machine?.lac ?? "-"}`,
+      `Template: ${template?.nome ?? "-"}`,
+      `Data/Hora: ${finalizedAt ? new Date(finalizedAt).toLocaleString("pt-BR") : "-"}`,
+      `Mantenedor: ${maintainer?.nome ?? "-"} (${maintainer?.matricula ?? "-"})`,
+      `Nº da O.S.: ${inspectionData.osNumero ?? "-"}`,
+    ];
+
+    headerLines.forEach(line => {
+      doc.text(line, margin, cursorY);
+      cursorY += 6;
+    });
+
+    const photo = await fetchImageData(machine?.fotoUrl ?? null);
+    if (photo) {
+      const imgWidth = 60;
+      const imgHeight = 45;
+      const x = pageWidth - margin - imgWidth;
+      const y = 20;
+      doc.addImage(photo.base64, photo.format, x, y, imgWidth, imgHeight);
+      cursorY = Math.max(cursorY, y + imgHeight + 8);
+    }
+
+    const signature = await fetchImageData(inspectionData.assinaturaUrl ?? null);
+    if (signature) {
+      if (cursorY > pageHeight - 60) {
+        doc.addPage();
+        cursorY = 20;
+      }
+      doc.setFontSize(12);
+      doc.text("Assinatura do mantenedor:", margin, cursorY);
+      cursorY += 6;
+      const imgWidth = 60;
+      const imgHeight = 30;
+      doc.addImage(signature.base64, signature.format, margin, cursorY, imgWidth, imgHeight);
+      cursorY += imgHeight + 10;
+    }
+
+    if (cursorY > pageHeight - 40) {
+      doc.addPage();
+      cursorY = 20;
+    }
+
+    doc.setFontSize(14);
+    doc.text("Itens do checklist", margin, cursorY);
+    cursorY += 8;
+
+    doc.setFontSize(12);
+    itens.forEach((item, index) => {
+      if (cursorY > pageHeight - 40) {
+        doc.addPage();
+        cursorY = 20;
+      }
+      const templateItem = templateItemsMap.get(item.templateItemId) ?? {};
+      const componente = templateItem?.componente ?? item.templateItemId;
+      doc.text(`${index + 1}. ${componente}`, margin, cursorY);
+      cursorY += 6;
+      doc.text(`Resultado: ${item.resultado ?? "-"}`, margin, cursorY);
+      cursorY += 6;
+      const observacao = item.observacaoItem ? String(item.observacaoItem) : "-";
+      const wrapped = doc.splitTextToSize(`Observação: ${observacao}`, pageWidth - margin * 2);
+      wrapped.forEach(line => {
+        doc.text(line, margin, cursorY);
+        cursorY += 6;
+      });
+      cursorY += 2;
+    });
+
+    if (cursorY > pageHeight - 40) {
+      doc.addPage();
+      cursorY = 20;
+    }
+
+    doc.setFontSize(14);
+    doc.text("Observações gerais", margin, cursorY);
+    cursorY += 8;
+
+    doc.setFontSize(12);
+    const observacoes = inspectionData.observacoes ?? "-";
+    const obsWrapped = doc.splitTextToSize(String(observacoes) || "-", pageWidth - margin * 2);
+    obsWrapped.forEach(line => {
+      if (cursorY > pageHeight - 20) {
+        doc.addPage();
+        cursorY = 20;
+      }
+      doc.text(line, margin, cursorY);
+      cursorY += 6;
+    });
+
+    const arrayBuffer = doc.output("arraybuffer");
+    const buffer = Buffer.from(arrayBuffer);
+    const fileName = `inspecao-${machine?.tag ?? params.id}.pdf`;
+
+    return new NextResponse(buffer, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="${fileName}"`,
+        "Content-Length": String(buffer.length),
+      },
+    });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      { error: extractMessage(err, "INTERNAL_ERROR") },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/inspecoes/route.ts
+++ b/src/app/api/inspecoes/route.ts
@@ -1,0 +1,313 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { FieldPath } from "firebase-admin/firestore";
+import type { QueryDocumentSnapshot, DocumentData } from "firebase-admin/firestore";
+import { adminDb, adminStorage } from "@/lib/firebase-admin";
+import { requireMaint } from "@/lib/guards";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const payloadSchema = z.object({
+  tag: z.string().trim().min(1),
+  osNumero: z.string().trim().min(1).optional(),
+  observacoes: z.string().trim().optional(),
+  assinaturaDataUrl: z.string().trim().optional(),
+  itens: z
+    .array(
+      z.object({
+        templateItemId: z.string().trim().min(1),
+        resultado: z.enum(["C", "NC", "NA"]),
+        observacaoItem: z.string().trim().optional(),
+        fotos: z.array(z.string().trim().min(1)).max(3).optional(),
+      })
+    )
+    .min(1),
+  resolveIssues: z.array(z.string().trim().min(1)).optional(),
+});
+
+type Payload = z.infer<typeof payloadSchema>;
+
+type TemplateItem = {
+  id?: string;
+  componente?: string;
+  criterio?: string;
+  oQueChecar?: string;
+  oQueFazer?: string;
+};
+
+function parseDataUrl(dataUrl: string) {
+  const match = dataUrl.match(/^data:(.+);base64,(.*)$/);
+  if (!match) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  const mime = match[1];
+  const base64 = match[2];
+  const buffer = Buffer.from(base64, "base64");
+  let extension = "bin";
+  if (mime === "image/png") extension = "png";
+  else if (mime === "image/jpeg" || mime === "image/jpg") extension = "jpg";
+  else if (mime === "image/webp") extension = "webp";
+  else if (mime === "image/svg+xml") extension = "svg";
+  return { buffer, mime, extension };
+}
+
+async function uploadDataUrl(path: string, dataUrl: string) {
+  const { buffer, mime, extension } = parseDataUrl(dataUrl);
+  const finalPath = path.endsWith(`.${extension}`) ? path : `${path}.${extension}`;
+  const bucket = adminStorage.bucket();
+  const file = bucket.file(finalPath);
+  await file.save(buffer, {
+    resumable: false,
+    contentType: mime,
+  });
+  await file.makePublic();
+  await file.setMetadata({
+    contentType: mime,
+    cacheControl: "public, max-age=31536000",
+  });
+  return `https://storage.googleapis.com/${bucket.name}/${finalPath}`;
+}
+
+function buildIssueDescription(item: TemplateItem, fallback: string) {
+  const componente = item.componente?.trim();
+  const criterio = item.criterio?.trim();
+  if (componente && criterio) {
+    return `NC no item ${componente} — ${criterio}`;
+  }
+  if (componente) {
+    return `NC no item ${componente}`;
+  }
+  return fallback;
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  let payload: Payload;
+  try {
+    payload = payloadSchema.parse(await req.json());
+  } catch (err: unknown) {
+    return NextResponse.json(
+      { error: extractMessage(err, "INVALID_PAYLOAD") },
+      { status: 422 }
+    );
+  }
+
+  try {
+    const machineQuery = await adminDb
+      .collection("maquinas")
+      .where("tag", "==", payload.tag)
+      .limit(1)
+      .get();
+
+    if (machineQuery.empty) {
+      return NextResponse.json({ error: "MACHINE_NOT_FOUND" }, { status: 404 });
+    }
+
+    const machineDoc = machineQuery.docs[0]!;
+    const machineData = machineDoc.data();
+
+    const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
+    if (!maintDoc.exists) {
+      return NextResponse.json({ error: "MAINTAINER_NOT_FOUND" }, { status: 403 });
+    }
+
+    const maintMachines = Array.isArray(maintDoc.data()?.machines)
+      ? (maintDoc.data()?.machines as string[])
+      : [];
+
+    if (!maintMachines.includes(machineDoc.id)) {
+      return NextResponse.json({ error: "FORBIDDEN" }, { status: 403 });
+    }
+
+    const templateId = String(machineData.templateId ?? "").trim();
+    if (!templateId) {
+      return NextResponse.json({ error: "TEMPLATE_NOT_DEFINED" }, { status: 400 });
+    }
+
+    const templateSnap = await adminDb.collection("templates").doc(templateId).get();
+    if (!templateSnap.exists) {
+      return NextResponse.json({ error: "TEMPLATE_NOT_FOUND" }, { status: 404 });
+    }
+
+    const templateData = templateSnap.data() ?? {};
+    const templateItems: TemplateItem[] = Array.isArray(templateData.itens) ? templateData.itens : [];
+    const templateMap = new Map<string, TemplateItem>();
+    templateItems.forEach(item => {
+      if (item.id) {
+        templateMap.set(item.id, item);
+      }
+    });
+
+    const uniqueItemIds = new Set<string>();
+    for (const item of payload.itens) {
+      if (!templateMap.has(item.templateItemId)) {
+        return NextResponse.json({ error: "INVALID_TEMPLATE_ITEM" }, { status: 422 });
+      }
+      if (uniqueItemIds.has(item.templateItemId)) {
+        return NextResponse.json({ error: "DUPLICATE_TEMPLATE_ITEM" }, { status: 422 });
+      }
+      uniqueItemIds.add(item.templateItemId);
+    }
+
+    const inspectionRef = adminDb.collection("inspecoes").doc();
+    const inspectionId = inspectionRef.id;
+
+    let assinaturaUrl: string | null = null;
+    if (payload.assinaturaDataUrl) {
+      assinaturaUrl = await uploadDataUrl(`public/signatures/${inspectionId}`, payload.assinaturaDataUrl);
+    }
+
+    const itensPayload: Array<{
+      templateItemId: string;
+      resultado: "C" | "NC" | "NA";
+      observacaoItem: string | null;
+      fotos: string[];
+    }> = [];
+
+    for (const item of payload.itens) {
+      const fotosBase64 = item.fotos ? item.fotos.slice(0, 3) : [];
+      const fotoUrls: string[] = [];
+      for (let index = 0; index < fotosBase64.length; index += 1) {
+        const dataUrl = fotosBase64[index]!;
+        const path = `public/inspections/${inspectionId}/${item.templateItemId}-${index + 1}`;
+        const url = await uploadDataUrl(path, dataUrl);
+        fotoUrls.push(url);
+      }
+      itensPayload.push({
+        templateItemId: item.templateItemId,
+        resultado: item.resultado,
+        observacaoItem: item.observacaoItem?.trim() ? item.observacaoItem.trim() : null,
+        fotos: fotoUrls,
+      });
+    }
+
+    const nowIso = new Date().toISOString();
+
+    const openIssuesSnap = await adminDb
+      .collection("issues")
+      .where("machineId", "==", machineDoc.id)
+      .where("status", "==", "aberta")
+      .get();
+
+    const openIssuesByTemplate = new Map<string, QueryDocumentSnapshot<DocumentData>>();
+
+    openIssuesSnap.docs.forEach(doc => {
+      const data = doc.data() ?? {};
+      if (data.templateItemId) {
+        openIssuesByTemplate.set(String(data.templateItemId), doc);
+      }
+    });
+
+    const issuesCriadas: string[] = [];
+    const issuesResolvidas: string[] = [];
+
+    const osNumero = payload.osNumero?.trim() ? payload.osNumero.trim() : null;
+    const observacoes = payload.observacoes?.trim() ? payload.observacoes.trim() : null;
+
+    for (const item of itensPayload) {
+      if (item.resultado !== "NC") {
+        continue;
+      }
+      const existingIssue = openIssuesByTemplate.get(item.templateItemId);
+      if (existingIssue) {
+        if (osNumero && existingIssue.data()?.osNumero !== osNumero) {
+          await existingIssue.ref.update({ osNumero });
+        }
+        continue;
+      }
+
+      const templateItem = templateMap.get(item.templateItemId) ?? {};
+      const descricao = item.observacaoItem || buildIssueDescription(templateItem, "NC identificada na inspeção");
+      const issueRef = adminDb.collection("issues").doc();
+      await issueRef.set({
+        machineId: machineDoc.id,
+        tag: machineData.tag ?? null,
+        templateItemId: item.templateItemId,
+        descricao,
+        osNumero: osNumero ?? null,
+        status: "aberta",
+        abertaEmInspecaoId: inspectionId,
+        createdAt: nowIso,
+      });
+      issuesCriadas.push(issueRef.id);
+    }
+
+    const resolveIssuesIds = payload.resolveIssues ?? [];
+    if (resolveIssuesIds.length > 0) {
+      const chunks: string[][] = [];
+      for (let i = 0; i < resolveIssuesIds.length; i += 10) {
+        chunks.push(resolveIssuesIds.slice(i, i + 10));
+      }
+      for (const chunk of chunks) {
+        const snap = await adminDb
+          .collection("issues")
+          .where(FieldPath.documentId(), "in", chunk)
+          .get();
+        for (const doc of snap.docs) {
+          const data = doc.data() ?? {};
+          if (data.machineId !== machineDoc.id || data.status === "resolvida") {
+            continue;
+          }
+          await doc.ref.update({
+            status: "resolvida",
+            resolvedAt: nowIso,
+            resolvidaEmInspecaoId: inspectionId,
+          });
+          issuesResolvidas.push(doc.id);
+        }
+      }
+    }
+
+    const qtdNC = itensPayload.filter(item => item.resultado === "NC").length;
+
+    await inspectionRef.set({
+      machine: {
+        machineId: machineDoc.id,
+        tag: machineData.tag ?? null,
+        nome: machineData.nome ?? null,
+        setor: machineData.setor ?? null,
+        unidade: machineData.unidade ?? null,
+        localUnidade: machineData.localUnidade ?? null,
+        lac: machineData.lac ?? null,
+        fotoUrl: machineData.fotoUrl ?? null,
+        templateId,
+      },
+      template: {
+        id: templateSnap.id,
+        nome: templateData.nome ?? null,
+      },
+      maintainer: {
+        maintId: auth.store.id!,
+        nome: auth.store.nome ?? null,
+        matricula: auth.store.matricula ?? null,
+      },
+      osNumero,
+      observacoes,
+      assinaturaUrl,
+      itens: itensPayload,
+      qtdNC,
+      createdAt: nowIso,
+      iniciadaEm: nowIso,
+      finalizadaEm: nowIso,
+      issuesCriadas,
+      issuesResolvidas,
+    });
+
+    return NextResponse.json({ id: inspectionId });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      { error: extractMessage(err, "INTERNAL_ERROR") },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/me/machines/route.ts
+++ b/src/app/api/me/machines/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { FieldPath } from "firebase-admin/firestore";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireMaint } from "@/lib/guards";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CHUNK_SIZE = 10;
+
+function chunkArray<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export async function GET() {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  try {
+    const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
+    if (!maintDoc.exists) {
+      return NextResponse.json({ error: "MAINTAINER_NOT_FOUND" }, { status: 403 });
+    }
+
+    const maintData = maintDoc.data() ?? {};
+    const machinesIds = Array.isArray(maintData.machines)
+      ? (maintData.machines as string[]).filter(Boolean)
+      : [];
+
+    if (machinesIds.length === 0) {
+      return NextResponse.json([]);
+    }
+
+    const chunks = chunkArray(machinesIds, CHUNK_SIZE);
+    const results: Array<{
+      id: string;
+      tag: string | null;
+      nome: string | null;
+      setor: string | null;
+      unidade: string | null;
+      fotoUrl: string | null;
+    }> = [];
+
+    for (const chunk of chunks) {
+      const snap = await adminDb
+        .collection("maquinas")
+        .where(FieldPath.documentId(), "in", chunk)
+        .get();
+
+      snap.docs.forEach(doc => {
+        const data = doc.data() ?? {};
+        if (data.ativo === false) {
+          return;
+        }
+        results.push({
+          id: doc.id,
+          tag: data.tag ?? null,
+          nome: data.nome ?? null,
+          setor: data.setor ?? null,
+          unidade: data.unidade ?? null,
+          fotoUrl: data.fotoUrl ?? null,
+        });
+      });
+    }
+
+    results.sort((a, b) => {
+      const nameA = (a.nome ?? "").toLowerCase();
+      const nameB = (b.nome ?? "").toLowerCase();
+      if (nameA && nameB) return nameA.localeCompare(nameB);
+      return (a.tag ?? "").localeCompare(b.tag ?? "");
+    });
+
+    return NextResponse.json(results);
+  } catch (error: unknown) {
+    const message = error instanceof Error && error.message ? error.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,39 +1,249 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Image from "next/image";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type MaintSessionInfo = {
+  nome?: string | null;
+  matricula?: string | null;
+};
+
+type MachineRecord = {
+  id: string;
+  tag: string | null;
+  nome: string | null;
+  setor: string | null;
+  unidade: string | null;
+  fotoUrl: string | null;
+};
 
 export default function HomeMaint() {
-  const [info, setInfo] = useState<any>(null);
+  const router = useRouter();
+  const [sessionLoading, setSessionLoading] = useState(true);
+  const [machinesLoading, setMachinesLoading] = useState(true);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+  const [machinesError, setMachinesError] = useState<string | null>(null);
+  const [session, setSession] = useState<MaintSessionInfo | null>(null);
+  const [machines, setMachines] = useState<MachineRecord[]>([]);
+  const [searchTag, setSearchTag] = useState("");
+  const [logoutLoading, setLogoutLoading] = useState(false);
 
   useEffect(() => {
-    (async () => {
+    let cancelled = false;
+    async function loadSession() {
+      setSessionLoading(true);
+      setSessionError(null);
       try {
-        const r = await fetch("/api/auth/maint/me", { cache: "no-store" });
-        if (r.ok) setInfo(await r.json());
-      } catch {}
-    })();
+        const response = await fetch("/api/auth/maint/me", { cache: "no-store" });
+        if (response.status === 401) {
+          if (!cancelled) {
+            setSession(null);
+            setSessionError("Sessão não encontrada. Faça login novamente.");
+          }
+          return;
+        }
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.error ?? "Falha ao carregar sessão");
+        }
+        const data = await response.json();
+        if (!cancelled) {
+          setSession({
+            nome: data.store?.nome ?? null,
+            matricula: data.store?.matricula ?? null,
+          });
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error && err.message ? err.message : "Falha ao carregar sessão";
+          setSessionError(message);
+          setSession(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setSessionLoading(false);
+        }
+      }
+    }
+    loadSession();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  async function logout() {
-    await fetch("/api/auth/maint/logout", { method: "POST" });
-    window.location.href = "/login";
-  }
+  useEffect(() => {
+    let cancelled = false;
+    async function loadMachines() {
+      if (!session) {
+        setMachines([]);
+        setMachinesLoading(false);
+        return;
+      }
+      setMachinesLoading(true);
+      setMachinesError(null);
+      try {
+        const response = await fetch("/api/me/machines", { cache: "no-store" });
+        if (response.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.error ?? "Falha ao carregar máquinas");
+        }
+        const data = (await response.json()) as MachineRecord[];
+        if (!cancelled) {
+          setMachines(data);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error && err.message ? err.message : "Falha ao carregar máquinas";
+          setMachinesError(message);
+          setMachines([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setMachinesLoading(false);
+        }
+      }
+    }
+    loadMachines();
+    return () => {
+      cancelled = true;
+    };
+  }, [session]);
+
+  const greeting = useMemo(() => {
+    if (!session) return null;
+    const nome = session.nome ? String(session.nome) : "";
+    const matricula = session.matricula ? String(session.matricula) : "";
+    return { nome, matricula };
+  }, [session]);
+
+  const handleSearch = useCallback(() => {
+    const trimmed = searchTag.trim();
+    if (!trimmed) return;
+    router.push(`/inspecao/${encodeURIComponent(trimmed)}`);
+  }, [router, searchTag]);
+
+  const handleLogout = useCallback(async () => {
+    try {
+      setLogoutLoading(true);
+      await fetch("/api/auth/maint/logout", { method: "POST" });
+      window.location.href = "/login";
+    } finally {
+      setLogoutLoading(false);
+    }
+  }, []);
 
   return (
-    <main className="p-8 space-y-4">
-      <h1 className="text-2xl font-bold">Home — Mantenedor</h1>
-      {info?.ok ? (
-        <div className="space-y-2">
-          <p>✅ Sessão ativa para: <b>{info.store?.nome}</b> (matrícula {info.store?.matricula})</p>
-          <button onClick={logout} className="rounded bg-black text-white px-4 py-2">
-            Sair
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-gray-900">Home do Mantenedor</h1>
+        {sessionLoading ? (
+          <div className="h-6 w-48 animate-pulse rounded bg-gray-200" />
+        ) : greeting ? (
+          <p className="text-gray-700">
+            Olá, <span className="font-medium">{greeting.nome}</span> (matrícula {greeting.matricula || "-"})
+          </p>
+        ) : (
+          <p className="text-sm text-red-600">{sessionError ?? "Sessão expirada."}</p>
+        )}
+        {greeting && (
+          <button
+            onClick={handleLogout}
+            disabled={logoutLoading}
+            className="inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {logoutLoading ? "Saindo..." : "Sair"}
           </button>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <p>⚠️ Não autenticado.</p>
-          <a className="text-blue-600 underline" href="/login">Ir para login</a>
-        </div>
+        )}
+      </header>
+
+      {greeting && (
+        <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-xl font-semibold text-gray-900">Minhas máquinas</h2>
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+              <input
+                value={searchTag}
+                onChange={event => setSearchTag(event.target.value.toUpperCase())}
+                onKeyDown={event => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    handleSearch();
+                  }
+                }}
+                placeholder="Buscar por TAG"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm uppercase text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200 sm:w-64"
+              />
+              <button
+                type="button"
+                onClick={handleSearch}
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+              >
+                Buscar
+              </button>
+            </div>
+          </div>
+
+          {machinesLoading ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="h-40 animate-pulse rounded-lg border border-gray-200 bg-gray-100" />
+              ))}
+            </div>
+          ) : machinesError ? (
+            <p className="text-sm text-red-600">{machinesError}</p>
+          ) : machines.length === 0 ? (
+            <p className="text-sm text-gray-600">Nenhuma máquina atribuída a você no momento.</p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {machines.map(machine => (
+                <article
+                  key={machine.id}
+                  className="flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+                >
+                  {machine.fotoUrl ? (
+                    <div className="relative h-40 w-full">
+                      <Image
+                        src={machine.fotoUrl}
+                        alt={`Foto da máquina ${machine.nome ?? machine.tag ?? ""}`}
+                        fill
+                        className="object-cover"
+                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-40 w-full items-center justify-center bg-gray-100 text-sm text-gray-500">
+                      Sem foto
+                    </div>
+                  )}
+                  <div className="flex flex-1 flex-col gap-2 p-4">
+                    <div className="space-y-1">
+                      <h3 className="text-lg font-semibold text-gray-900">{machine.nome ?? "Máquina"}</h3>
+                      <p className="text-sm text-gray-600">TAG: {machine.tag ?? "-"}</p>
+                      <p className="text-xs text-gray-500">Setor: {machine.setor ?? "-"}</p>
+                      <p className="text-xs text-gray-500">Unidade: {machine.unidade ?? "-"}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!machine.tag) return;
+                        router.push(`/inspecao/${encodeURIComponent(machine.tag)}`);
+                      }}
+                      disabled={!machine.tag}
+                      className="mt-auto inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Inspecionar
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
       )}
     </main>
   );

--- a/src/app/inspecao/[tag]/page.tsx
+++ b/src/app/inspecao/[tag]/page.tsx
@@ -1,74 +1,161 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Image from "next/image";
-import { useEffect, useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import type { ChangeEvent } from "react";
+import type SignatureCanvasType from "react-signature-canvas";
 
-interface MachineSnapshot {
-  machineId: string;
+const SignatureCanvas = dynamic(() => import("react-signature-canvas"), { ssr: false });
+
+type MaintainerInfo = {
+  id: string;
+  nome: string | null;
+  matricula: string | null;
+};
+
+type MachineInfo = {
+  id: string;
   tag: string | null;
   nome: string | null;
   setor: string | null;
   unidade: string | null;
   localUnidade: string | null;
+  lac: string | null;
   fotoUrl: string | null;
   templateId: string;
-}
+};
 
-interface TemplateItem {
+type TemplateItem = {
   id?: string;
-  componente?: string;
-  oQueChecar?: string;
-  instrumento?: string;
-  criterio?: string;
-  oQueFazer?: string;
+  componente?: string | null;
+  oQueChecar?: string | null;
+  instrumento?: string | null;
+  criterio?: string | null;
+  oQueFazer?: string | null;
   imagemItemUrl?: string | null;
-  ordem?: number;
-}
+  ordem?: number | null;
+};
 
-interface TemplateRecord {
+type TemplateInfo = {
   id: string;
-  nome?: string;
+  nome: string | null;
   imagemUrl?: string | null;
-  itens?: TemplateItem[];
-}
+  itens: TemplateItem[];
+};
 
-interface InspectionContextResponse {
-  machine: MachineSnapshot;
-  template: TemplateRecord;
-  issues: unknown[];
+type IssueRecord = {
+  id: string;
+  templateItemId: string | null;
+  descricao: string | null;
+  osNumero: string | null;
+  createdAt: string | null;
+};
+
+type InspectionContext = {
+  maintainer: MaintainerInfo;
+  machine: MachineInfo;
+  template: TemplateInfo;
+  openIssues: IssueRecord[];
+};
+
+type ItemFormState = {
+  resultado: "" | "C" | "NC" | "NA";
+  observacao: string;
+  fotos: File[];
+  fileKey: number;
+};
+
+type FeedbackState = {
+  type: "success" | "error";
+  message: string;
+};
+
+const RESULT_OPTIONS: Array<{ value: "C" | "NC" | "NA"; label: string; description: string }> = [
+  { value: "C", label: "C", description: "Conforme" },
+  { value: "NC", label: "NC", description: "Não conforme" },
+  { value: "NA", label: "N/A", description: "Não se aplica" },
+];
+
+async function fileToDataUrl(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+      } else {
+        reject(new Error("Falha ao ler arquivo"));
+      }
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Falha ao ler arquivo"));
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 export default function InspectionPage() {
   const params = useParams<{ tag: string }>();
-  const tagParam = params?.tag;
-  const tag = useMemo(() => {
-    if (!tagParam) return "";
-    return Array.isArray(tagParam) ? tagParam[0] ?? "" : tagParam;
-  }, [tagParam]);
+  const tagParam = Array.isArray(params?.tag) ? params?.tag?.[0] : params?.tag ?? "";
+  const tag = useMemo(() => tagParam?.trim() ?? "", [tagParam]);
 
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [context, setContext] = useState<InspectionContext | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [context, setContext] = useState<InspectionContextResponse | null>(null);
+  const [itemsState, setItemsState] = useState<Record<string, ItemFormState>>({});
+  const [osNumero, setOsNumero] = useState("");
+  const [observacoes, setObservacoes] = useState("");
+  const [resolveIssues, setResolveIssues] = useState<Record<string, boolean>>({});
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [savingAction, setSavingAction] = useState<"save" | "save-new" | null>(null);
+  const [lastInspectionId, setLastInspectionId] = useState<string | null>(null);
+  const [reloadCounter, setReloadCounter] = useState(0);
+  const signatureRef = useRef<SignatureCanvasType | null>(null);
+  const [signatureTouched, setSignatureTouched] = useState(false);
+
+  useEffect(() => {
+    if (searchParams?.get("ok") === "1") {
+      setFeedback({ type: "success", message: "Inspeção salva" });
+    }
+    const idParam = searchParams?.get("id");
+    if (idParam) {
+      setLastInspectionId(idParam);
+    }
+  }, [searchParams]);
+
+  const sortedItems = useMemo(() => {
+    if (!context?.template?.itens) return [] as TemplateItem[];
+    return [...context.template.itens].sort((a, b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+  }, [context?.template?.itens]);
+
+  const refreshContext = useCallback(() => {
+    setReloadCounter(prev => prev + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
-
-    async function load() {
-      if (!tag) return;
+    async function loadContext() {
+      if (!tag) {
+        setContext(null);
+        setLoading(false);
+        setError("TAG inválida.");
+        return;
+      }
       setLoading(true);
       setError(null);
-
       try {
         const response = await fetch(`/api/inspecao/context?tag=${encodeURIComponent(tag)}`, {
           cache: "no-store",
         });
-
         if (response.status === 401) {
           window.location.href = "/login";
           return;
         }
-
         if (!response.ok) {
           const payload = await response.json().catch(() => null);
           const message =
@@ -81,24 +168,16 @@ export default function InspectionPage() {
               : typeof payload?.error === "string"
               ? payload.error
               : "Falha ao carregar dados da inspeção.";
-          if (!cancelled) {
-            setError(message);
-            setContext(null);
-          }
-          return;
+          throw new Error(message);
         }
-
-        const data = (await response.json()) as InspectionContextResponse;
+        const data = (await response.json()) as InspectionContext;
         if (!cancelled) {
           setContext(data);
           setError(null);
         }
       } catch (err: unknown) {
         if (!cancelled) {
-          const message =
-            err instanceof Error && err.message
-              ? err.message
-              : "Falha ao carregar dados da inspeção.";
+          const message = err instanceof Error && err.message ? err.message : "Falha ao carregar dados da inspeção.";
           setError(message);
           setContext(null);
         }
@@ -108,158 +187,560 @@ export default function InspectionPage() {
         }
       }
     }
-
-    load();
-
+    loadContext();
     return () => {
       cancelled = true;
     };
-  }, [tag]);
+  }, [tag, reloadCounter]);
+
+  const resetForm = useCallback(() => {
+    if (!context?.template?.itens) return;
+    const initialState: Record<string, ItemFormState> = {};
+    context.template.itens
+      .filter(item => item.id)
+      .forEach((item, index) => {
+        initialState[item.id!] = {
+          resultado: "",
+          observacao: "",
+          fotos: [],
+          fileKey: Date.now() + index,
+        };
+      });
+    setItemsState(initialState);
+    setOsNumero("");
+    setObservacoes("");
+    setResolveIssues({});
+    setSignatureTouched(false);
+    if (signatureRef.current && typeof signatureRef.current.clear === "function") {
+      signatureRef.current.clear();
+    }
+  }, [context?.template?.itens]);
+
+  useEffect(() => {
+    if (context) {
+      resetForm();
+    }
+  }, [context, resetForm]);
+
+  const hasNC = useMemo(() => {
+    return Object.values(itemsState).some(item => item.resultado === "NC");
+  }, [itemsState]);
+
+  const handleResultadoChange = useCallback((itemId: string, value: "C" | "NC" | "NA") => {
+    setItemsState(prev => ({
+      ...prev,
+      [itemId]: {
+        ...(prev[itemId] ?? { resultado: "", observacao: "", fotos: [], fileKey: Date.now() }),
+        resultado: value,
+      },
+    }));
+  }, []);
+
+  const handleObservacaoChange = useCallback((itemId: string, value: string) => {
+    setItemsState(prev => ({
+      ...prev,
+      [itemId]: {
+        ...(prev[itemId] ?? { resultado: "", observacao: "", fotos: [], fileKey: Date.now() }),
+        observacao: value,
+      },
+    }));
+  }, []);
+
+  const handleFotosChange = useCallback((itemId: string, event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []).slice(0, 3);
+    setItemsState(prev => ({
+      ...prev,
+      [itemId]: {
+        ...(prev[itemId] ?? { resultado: "", observacao: "", fotos: [], fileKey: Date.now() }),
+        fotos: files,
+        fileKey: (prev[itemId]?.fileKey ?? Date.now()) + 1,
+      },
+    }));
+  }, []);
+
+  const handleResolveIssue = useCallback((issueId: string, checked: boolean) => {
+    setResolveIssues(prev => ({
+      ...prev,
+      [issueId]: checked,
+    }));
+  }, []);
+
+  const submitInspection = useCallback(
+    async (mode: "save" | "save-new") => {
+      if (!context?.machine?.tag) {
+        setFeedback({ type: "error", message: "Máquina sem TAG configurada." });
+        return;
+      }
+      if (saving) return;
+      setSaving(true);
+      setSavingAction(mode);
+      setFeedback(null);
+      try {
+        const payloadItems = [] as Array<{
+          templateItemId: string;
+          resultado: "C" | "NC" | "NA";
+          observacaoItem?: string;
+          fotos?: string[];
+        }>;
+
+        for (const item of sortedItems) {
+          if (!item.id) continue;
+          const state = itemsState[item.id];
+          if (!state || !state.resultado) {
+            setFeedback({ type: "error", message: "Selecione C / NC / N/A para todos os itens." });
+            setSaving(false);
+            setSavingAction(null);
+            return;
+          }
+          const fotosBase64 = state.fotos.length
+            ? await Promise.all(state.fotos.map(file => fileToDataUrl(file)))
+            : undefined;
+          payloadItems.push({
+            templateItemId: item.id,
+            resultado: state.resultado,
+            observacaoItem: state.observacao.trim() ? state.observacao.trim() : undefined,
+            fotos: fotosBase64,
+          });
+        }
+
+        if (payloadItems.length === 0) {
+          setFeedback({ type: "error", message: "Template sem itens configurados." });
+          setSaving(false);
+          setSavingAction(null);
+          return;
+        }
+
+        let assinaturaDataUrl: string | undefined;
+        if (signatureRef.current && typeof signatureRef.current.isEmpty === "function") {
+          const empty = signatureRef.current.isEmpty();
+          if (!empty) {
+            assinaturaDataUrl = signatureRef.current.toDataURL("image/png");
+          }
+        }
+
+        const resolveIds = Object.entries(resolveIssues)
+          .filter(([, checked]) => checked)
+          .map(([issueId]) => issueId);
+
+        const response = await fetch("/api/inspecoes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            tag: context.machine.tag,
+            osNumero: osNumero.trim() || undefined,
+            observacoes: observacoes.trim() || undefined,
+            assinaturaDataUrl,
+            itens: payloadItems,
+            resolveIssues: resolveIds.length ? resolveIds : undefined,
+          }),
+        });
+
+        if (response.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          const message = typeof payload?.error === "string" ? payload.error : "Falha ao salvar inspeção.";
+          throw new Error(message);
+        }
+
+        const data = await response.json();
+        const inspectionId = data?.id ? String(data.id) : null;
+        if (inspectionId) {
+          setLastInspectionId(inspectionId);
+        }
+
+        refreshContext();
+
+        if (mode === "save") {
+          router.replace(`/inspecao/${encodeURIComponent(context.machine.tag)}?ok=1${inspectionId ? `&id=${inspectionId}` : ""}`);
+        } else {
+          setFeedback({ type: "success", message: "Inspeção salva" });
+          resetForm();
+          if (inspectionId) {
+            setLastInspectionId(inspectionId);
+          }
+          window.scrollTo({ top: 0, behavior: "smooth" });
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error && err.message ? err.message : "Falha ao salvar inspeção.";
+        setFeedback({ type: "error", message });
+      } finally {
+        setSaving(false);
+        setSavingAction(null);
+      }
+    },
+    [context, itemsState, observacoes, osNumero, refreshContext, resetForm, resolveIssues, router, saving, sortedItems]
+  );
 
   if (!tag) {
     return (
-      <main className="max-w-4xl mx-auto p-4">
-        <p className="text-red-600">TAG inválida.</p>
+      <main className="mx-auto max-w-5xl px-4 py-6">
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Informe uma TAG válida para iniciar a inspeção.
+        </div>
       </main>
     );
   }
 
   return (
-    <main className="max-w-5xl mx-auto p-4 space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-bold">Inspeção — {tag.toUpperCase()}</h1>
-        {loading && <p>Carregando dados da máquina...</p>}
-        {error && !loading && <p className="text-red-600">{error}</p>}
+    <main className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6">
+      <header className="space-y-4">
+        <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-gray-900">Inspeção — {tag.toUpperCase()}</h1>
+            {context?.maintainer && (
+              <p className="text-sm text-gray-600">
+                Mantenedor: <span className="font-medium">{context.maintainer.nome ?? "-"}</span> (matrícula
+                {" "}
+                {context.maintainer.matricula ?? "-"})
+              </p>
+            )}
+          </div>
+          <a
+            href={lastInspectionId ? `/api/inspecoes/${lastInspectionId}/pdf` : "#"}
+            target="_blank"
+            rel="noreferrer"
+            className={`inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition ${
+              lastInspectionId
+                ? "border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100"
+                : "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
+            }`}
+            aria-disabled={!lastInspectionId}
+          >
+            Gerar PDF
+          </a>
+        </div>
+        {feedback && (
+          <div
+            className={`rounded-md border px-4 py-3 text-sm ${
+              feedback.type === "success"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                : "border-red-200 bg-red-50 text-red-700"
+            }`}
+          >
+            {feedback.message}
+          </div>
+        )}
+        {loading && (
+          <div className="space-y-3">
+            <div className="h-6 w-40 animate-pulse rounded bg-gray-200" />
+            <div className="h-40 animate-pulse rounded-lg bg-gray-100" />
+          </div>
+        )}
+        {error && !loading && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div>
+        )}
       </header>
 
       {context && !loading && !error && (
-        <div className="space-y-8">
-          <section className="rounded-lg border bg-white shadow-sm">
-            <div className="p-6 space-y-4">
-              <div className="flex flex-col gap-6 md:flex-row md:items-start">
-                <div className="flex-1 space-y-2">
-                  <h2 className="text-2xl font-semibold">{context.machine.nome ?? "Máquina"}</h2>
-                  <div className="text-gray-600 space-y-1">
-                    <p>
-                      <span className="font-medium">TAG:</span> {context.machine.tag ?? "-"}
-                    </p>
-                    <p>
-                      <span className="font-medium">Setor:</span> {context.machine.setor ?? "-"}
-                    </p>
-                    <p>
-                      <span className="font-medium">Unidade:</span> {context.machine.unidade ?? "-"}
-                    </p>
-                    <p>
-                      <span className="font-medium">Local na unidade:</span> {context.machine.localUnidade ?? "-"}
-                    </p>
-                  </div>
+        <>
+          <section className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <div className="flex-1 space-y-2">
+                <h2 className="text-2xl font-semibold text-gray-900">{context.machine.nome ?? "Máquina"}</h2>
+                <div className="text-sm text-gray-600">
+                  <p>Unidade: {context.machine.unidade ?? "-"}</p>
+                  <p>Local: {context.machine.localUnidade ?? "-"}</p>
+                  <p>Setor: {context.machine.setor ?? "-"}</p>
+                  <p>LAC: {context.machine.lac ?? "-"}</p>
+                  <p>TAG: {context.machine.tag ?? "-"}</p>
                 </div>
-                {context.machine.fotoUrl ? (
-                  <div className="relative h-40 w-40 overflow-hidden rounded-lg border bg-gray-50">
-                    <Image
-                      src={context.machine.fotoUrl}
-                      alt={`Foto da máquina ${context.machine.nome ?? context.machine.tag}`}
-                      fill
-                      sizes="160px"
-                      className="object-cover"
-                    />
-                  </div>
-                ) : null}
               </div>
-              <div className="flex flex-wrap gap-3">
+              {context.machine.fotoUrl ? (
+                <div className="relative h-40 w-full overflow-hidden rounded-md border bg-gray-50 md:h-48 md:w-48">
+                  <Image
+                    src={context.machine.fotoUrl}
+                    alt={`Foto da máquina ${context.machine.nome ?? context.machine.tag ?? ""}`}
+                    fill
+                    className="object-cover"
+                    sizes="192px"
+                  />
+                </div>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="osNumero">
+                  Nº da O.S.
+                </label>
+                <input
+                  id="osNumero"
+                  value={osNumero}
+                  onChange={event => setOsNumero(event.target.value.toUpperCase())}
+                  placeholder="Opcional"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm uppercase text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="observacoes">
+                  Observações gerais
+                </label>
+                <textarea
+                  id="observacoes"
+                  value={observacoes}
+                  onChange={event => setObservacoes(event.target.value)}
+                  placeholder="Registre observações relevantes"
+                  rows={3}
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+                />
+              </div>
+            </div>
+
+            {hasNC && !osNumero.trim() && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+                Existem itens marcados como NC. Considere informar o Nº da O.S.
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-gray-700">Assinatura do mantenedor</p>
+              <div className="h-40 w-full overflow-hidden rounded-md border border-dashed border-gray-300 bg-gray-50">
+                {typeof window !== "undefined" && (
+                  <SignatureCanvas
+                    ref={signatureRef}
+                    penColor="#111827"
+                    backgroundColor="transparent"
+                    onEnd={() => setSignatureTouched(true)}
+                    canvasProps={{ className: "h-full w-full" }}
+                  />
+                )}
+              </div>
+              <div className="flex items-center gap-3 text-sm">
                 <button
                   type="button"
-                  disabled
-                  className="rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-600 cursor-not-allowed"
+                  onClick={() => {
+                    if (signatureRef.current && typeof signatureRef.current.clear === "function") {
+                      signatureRef.current.clear();
+                      setSignatureTouched(false);
+                    }
+                  }}
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
                 >
-                  Salvar
+                  Limpar assinatura
                 </button>
-                <button
-                  type="button"
-                  disabled
-                  className="rounded-md bg-gray-300 px-4 py-2 text-sm font-medium text-gray-600 cursor-not-allowed"
-                >
-                  Salvar e Nova
-                </button>
+                {!signatureTouched && <span className="text-xs text-gray-500">Assine utilizando o campo acima.</span>}
               </div>
             </div>
           </section>
 
           <section className="space-y-4">
             <div>
-              <h2 className="text-2xl font-semibold">Itens do template</h2>
-              <p className="text-sm text-gray-600">
-                Template: {context.template.nome ?? "Sem nome"}
-              </p>
+              <h2 className="text-2xl font-semibold text-gray-900">Checklist</h2>
+              <p className="text-sm text-gray-600">Template: {context.template.nome ?? "-"}</p>
             </div>
-            <div className="space-y-4">
-              {Array.isArray(context.template.itens) && context.template.itens.length > 0 ? (
-                context.template.itens
-                  .slice()
-                  .sort((a, b) => (a.ordem ?? 0) - (b.ordem ?? 0))
-                  .map(item => (
-                    <article key={item.id ?? `${item.componente}-${item.ordem}`}
-                      className="rounded-lg border bg-white p-4 shadow-sm space-y-3"
-                    >
-                      <header className="flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between">
-                        <h3 className="text-lg font-semibold">
-                          {item.ordem ? `${item.ordem}. ` : ""}
-                          {item.componente ?? "Item sem nome"}
-                        </h3>
-                        {item.instrumento && (
-                          <span className="text-sm text-gray-500">
-                            Instrumento: {item.instrumento}
-                          </span>
-                        )}
+
+            {sortedItems.length === 0 ? (
+              <div className="rounded-md border border-gray-200 bg-white p-4 text-sm text-gray-600">
+                Nenhum item configurado para este template.
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                {sortedItems.map(item => {
+                  if (!item.id) return null;
+                  const state = itemsState[item.id];
+                  return (
+                    <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                      <header className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                        <div className="space-y-1">
+                          <h3 className="text-lg font-semibold text-gray-900">
+                            {item.ordem ? `${item.ordem}. ` : ""}
+                            {item.componente ?? "Item sem nome"}
+                          </h3>
+                          {item.oQueChecar && (
+                            <p className="text-sm text-gray-600">O que checar: {item.oQueChecar}</p>
+                          )}
+                          {item.instrumento && (
+                            <p className="text-sm text-gray-600">Instrumento: {item.instrumento}</p>
+                          )}
+                          {item.criterio && (
+                            <p className="text-sm text-gray-600">Critério: {item.criterio}</p>
+                          )}
+                          {item.oQueFazer && (
+                            <p className="text-sm text-gray-600">O que fazer: {item.oQueFazer}</p>
+                          )}
+                        </div>
+                        {item.imagemItemUrl ? (
+                          <div className="relative h-32 w-full overflow-hidden rounded-md border bg-gray-50 md:h-36 md:w-36">
+                            <Image
+                              src={item.imagemItemUrl}
+                              alt={`Imagem do item ${item.componente ?? item.id}`}
+                              fill
+                              className="object-cover"
+                              sizes="144px"
+                            />
+                          </div>
+                        ) : null}
                       </header>
-                      {item.oQueChecar && (
-                        <p>
-                          <span className="font-medium">O que checar:</span> {item.oQueChecar}
-                        </p>
-                      )}
-                      {item.criterio && (
-                        <p>
-                          <span className="font-medium">Critério:</span> {item.criterio}
-                        </p>
-                      )}
-                      {item.oQueFazer && (
-                        <p>
-                          <span className="font-medium">O que fazer:</span> {item.oQueFazer}
-                        </p>
-                      )}
-                      {item.imagemItemUrl && (
-                        <div className="relative mt-2 h-48 w-full overflow-hidden rounded-md border bg-gray-50">
-                          <Image
-                            src={item.imagemItemUrl}
-                            alt={`Imagem do item ${item.componente ?? item.ordem ?? ""}`}
-                            fill
-                            sizes="(min-width: 768px) 480px, 100vw"
-                            className="object-cover"
+
+                      <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                        <div className="space-y-2">
+                          <p className="text-sm font-medium text-gray-700">Resultado</p>
+                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                            {RESULT_OPTIONS.map(option => {
+                              const isSelected = state?.resultado === option.value;
+                              const baseClasses =
+                                option.value === "C"
+                                  ? "border-emerald-500 text-emerald-700 bg-emerald-50"
+                                  : option.value === "NC"
+                                  ? "border-red-500 text-red-700 bg-red-50"
+                                  : "border-slate-400 text-slate-600 bg-slate-50";
+                              const idleClasses =
+                                option.value === "C"
+                                  ? "hover:border-emerald-400 hover:bg-emerald-50"
+                                  : option.value === "NC"
+                                  ? "hover:border-red-400 hover:bg-red-50"
+                                  : "hover:border-slate-300 hover:bg-slate-50";
+                              return (
+                                <label
+                                  key={option.value}
+                                  className={`flex cursor-pointer flex-col items-center justify-center gap-1 rounded-md border px-3 py-3 text-sm font-medium transition ${
+                                    isSelected ? baseClasses : `border-gray-200 bg-white text-gray-600 ${idleClasses}`
+                                  }`}
+                                >
+                                  <input
+                                    type="radio"
+                                    className="sr-only"
+                                    name={`resultado-${item.id}`}
+                                    value={option.value}
+                                    checked={state?.resultado === option.value}
+                                    onChange={() => handleResultadoChange(item.id!, option.value)}
+                                  />
+                                  <span>{option.label}</span>
+                                  <span className="text-xs font-normal">{option.description}</span>
+                                </label>
+                              );
+                            })}
+                          </div>
+                        </div>
+
+                        <div className="space-y-2">
+                          <label className="text-sm font-medium text-gray-700" htmlFor={`observacao-${item.id}`}>
+                            Observação do item (opcional)
+                          </label>
+                          <textarea
+                            id={`observacao-${item.id}`}
+                            value={state?.observacao ?? ""}
+                            onChange={event => handleObservacaoChange(item.id!, event.target.value)}
+                            rows={3}
+                            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
                           />
                         </div>
-                      )}
-                    </article>
-                  ))
-              ) : (
-                <p className="text-gray-600">Nenhum item configurado para este template.</p>
-              )}
-            </div>
-          </section>
+                      </div>
 
-          <section className="space-y-2">
-            <h2 className="text-2xl font-semibold">Avarias em aberto</h2>
-            {Array.isArray(context.issues) && context.issues.length > 0 ? (
-              <ul className="list-disc space-y-2 pl-5 text-gray-700">
-                {context.issues.map((issue, index) => (
-                  <li key={index}>Issue #{index + 1}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-gray-600">Nenhuma avaria em aberto para esta TAG.</p>
+                      <div className="mt-3 space-y-2">
+                        <label className="text-sm font-medium text-gray-700" htmlFor={`fotos-${item.id}`}>
+                          Fotos do item (até 3)
+                        </label>
+                        <input
+                          key={state?.fileKey ?? `${item.id}-0`}
+                          id={`fotos-${item.id}`}
+                          type="file"
+                          accept="image/*"
+                          multiple
+                          onChange={event => handleFotosChange(item.id!, event)}
+                          className="text-sm text-gray-600"
+                        />
+                        <p className="text-xs text-gray-500">Arquivos aceitos: imagens (máximo de 3 fotos por item).</p>
+                        {state?.fotos?.length ? (
+                          <ul className="list-disc space-y-1 pl-5 text-xs text-gray-600">
+                            {state.fotos.map(file => (
+                              <li key={file.name}>{file.name}</li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
             )}
           </section>
-        </div>
+
+          <section className="space-y-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            <h2 className="text-xl font-semibold text-gray-900">Issues abertas</h2>
+            {context.openIssues.length === 0 ? (
+              <p className="text-sm text-gray-600">Nenhuma issue aberta para esta TAG.</p>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {context.openIssues.map(issue => (
+                  <label
+                    key={issue.id}
+                    className="flex cursor-pointer flex-col gap-1 rounded-md border border-gray-200 bg-white p-3 text-sm text-gray-700 transition hover:border-blue-300 hover:bg-blue-50"
+                  >
+                    <div className="flex items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={!!resolveIssues[issue.id]}
+                        onChange={event => handleResolveIssue(issue.id, event.target.checked)}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      <div className="space-y-1">
+                        <p className="font-medium">{issue.descricao ?? "Issue sem descrição"}</p>
+                        {issue.templateItemId && (
+                          <p className="text-xs text-gray-500">Item: {issue.templateItemId}</p>
+                        )}
+                        {issue.osNumero && (
+                          <p className="text-xs text-gray-500">O.S.: {issue.osNumero}</p>
+                        )}
+                        {issue.createdAt && (
+                          <p className="text-xs text-gray-400">
+                            Aberta em {new Date(issue.createdAt).toLocaleString("pt-BR")}
+                          </p>
+                        )}
+                        <p className="text-xs text-gray-600">Marcar como resolvida nesta inspeção</p>
+                      </div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </section>
+        </>
       )}
+
+      <footer className="sticky bottom-0 left-0 right-0 z-10 -mx-4 border-t border-gray-200 bg-white/90 px-4 py-4 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-3">
+            <a
+              href={lastInspectionId ? `/api/inspecoes/${lastInspectionId}/pdf` : "#"}
+              target="_blank"
+              rel="noreferrer"
+              className={`inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition ${
+                lastInspectionId
+                  ? "border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100"
+                  : "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
+              }`}
+              aria-disabled={!lastInspectionId}
+            >
+              Gerar PDF
+            </a>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => submitInspection("save")}
+              className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving && savingAction === "save" ? "Salvando..." : "Salvar"}
+            </button>
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => submitInspection("save-new")}
+              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving && savingAction === "save-new" ? "Salvando..." : "Salvar & Nova"}
+            </button>
+          </div>
+        </div>
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add maintainer-scoped machine listing and enriched inspection context endpoints
- implement inspection creation API with file uploads, issue handling, and PDF generation route
- rebuild maintainer home and inspection UI to drive the new workflow with checklist entry, signature, and photo uploads

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5f8a5564832886392973f0940d30